### PR TITLE
[AV-989] Create a versioning system for TARS log files

### DIFF
--- a/TARS/.gitignore
+++ b/TARS/.gitignore
@@ -3,3 +3,5 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+
+src/mcu_main/gen/

--- a/TARS/generate_git_hash.py
+++ b/TARS/generate_git_hash.py
@@ -1,0 +1,31 @@
+# Script to generate `hash.h` file containing the latest commit hash that modified packet.h
+#
+# Autogenerates src/mcu_main/gen/git_hash.c
+
+import os, subprocess
+
+PACKET_H_PATH = "src/common/packet.h"
+FILE_PATH = "src/mcu_main/gen/git_hash.c"
+
+
+# Get the git hash  of the latest commit that modified packet.h
+git_command = ["git", "log", "-n", "1", "--pretty=format:%H", "--", PACKET_H_PATH]
+git_hash = subprocess.run(git_command, stdout=subprocess.PIPE).stdout.decode('utf-8')
+git_hash = git_hash[:-1]  # get rid of trailing new line
+
+
+# note: git hashes are always 40 characters
+file_contents = f"""
+/*
+ * Auto generated file containing the git hash of the latest commit that modified packet.h.
+ *
+ * See generate_git_hash.py
+ */
+char PACKET_H_GIT_HASH[41] = "{git_hash}";
+"""
+
+os.makedirs(os.path.dirname(FILE_PATH), exist_ok=True)
+with open(FILE_PATH, "w") as f:
+        f.write(file_contents)
+
+print(f"Wrote hash {git_hash} to file {FILE_PATH}")

--- a/TARS/platformio.ini
+++ b/TARS/platformio.ini
@@ -18,7 +18,7 @@ platform = teensy
 board = teensy41
 framework = arduino
 upload_protocol = teensy-cli
-extra_scripts = extra_script.py
+extra_scripts = extra_script.py, generate_git_hash.py
 build_flags = -Wno-deprecated-declarations -Wno-unused-local-typedefs -Wno-reorder ; turn off all the warnings from eigen
 lib_deps = 
   PaulStoffregen/PWMServo

--- a/TARS/src/mcu_main/SDLogger.cpp
+++ b/TARS/src/mcu_main/SDLogger.cpp
@@ -78,6 +78,10 @@ void SDLogger::init() {
         sd_file = SD.open(data_name, FILE_WRITE_BEGIN);
         // print header to file on sd card that lists each variable that is logged
         // sd_file.println("binary logging of sensor_data_t");
+
+        // Write the git hash of packet.h to the start of the file
+        sd_file.write((const uint8_t*)PACKET_H_GIT_HASH, sizeof(PACKET_H_GIT_HASH));
+
         sd_file.flush();
 
         Serial.println(sd_file.name());

--- a/TARS/src/mcu_main/SDLogger.h
+++ b/TARS/src/mcu_main/SDLogger.h
@@ -5,6 +5,9 @@
 
 #include "mcu_main/dataLog.h"
 
+// Latest git hash of packet.h (see gen/git_hash.c)
+extern char PACKET_H_GIT_HASH[41];
+
 class SDLogger;
 extern SDLogger sd_logger;
 


### PR DESCRIPTION
Adds a build script to get the latest git hash of `packet.h` and prepends the hash to TARS log file.